### PR TITLE
Temporary Fix Xiaohongshu for #17: Resolves Duplicate Items in Feed

### DIFF
--- a/src/lib/xiaohongshu/user.js
+++ b/src/lib/xiaohongshu/user.js
@@ -48,6 +48,7 @@ let deal = async (ctx) => {
 			n.map(({ noteCard }) => ({
 				title: noteCard.displayTitle,
 				link: `${url}/${noteCard.noteId}`,
+				guid: noteCard.displayTitle,
 				description: `<img src ="${noteCard.cover.infoList.pop().url}"><br>${noteCard.displayTitle}`,
 				author: noteCard.user.nickname,
 				upvotes: noteCard.interactInfo.likedCount,


### PR DESCRIPTION
This PR addresses the issue mentioned in #17, "RSS feed only showing the pinned post without updates". After some investigation, `noteCard.noteId` is not available due to changes on the site. As a result, the links for all note items in the feed were identical, causing RSS readers to treat them as duplicates and only display a single one of the notes.

This PR introduces a `guid` field using `noteCard.displayTitle` as a unique identifier for each note. It ensures that RSS readers can distinguish between the different notes, avoiding duplicate entries. User can then be alerted the update of the notes and check them from the user page.

Future Considerations:

-   A more permanent fix will require addressing adapting to the site's structural changes,  `xsecToken` expiration 
-   For improved compatibility, we could consider using SHA1 or Base64 encoding of the title for the `guid` field instead of the raw title itself.

This change helps mitigate the issue for now, ensuring the feed remains functional for RSS users.