### PR TITLE
fix: correct xiaohongshu RSS content type for FreshRSS

### DIFF
--- a/src/lib/xiaohongshu/user.js
+++ b/src/lib/xiaohongshu/user.js
@@ -73,8 +73,8 @@ let deal = async (ctx) => {
 		}));
 	};
 
-    ctx.header('Content-Type', 'application/xml');
-	return ctx.text(
+	ctx.header('Content-Type', 'application/rss+xml; charset=UTF-8');
+	return ctx.body(
 		renderRss2({
 			title,
 			description,


### PR DESCRIPTION
## Summary
- fix the Xiaohongshu RSS route returning text/plain
- return the feed as RSS XML so FreshRSS can subscribe successfully

## Problem
FreshRSS could not recognize the feed because the route responded with status 200 but content-type text/plain; charset=UTF-8.

## Fix
- replace Hono ctx.text() with ctx.body()
- set Content-Type to application/rss+xml; charset=UTF-8