### PR TITLE
fix(build): restore npm build script for Workers Builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
+		"build": "wrangler deploy --dry-run",
 		"deploy": "wrangler deploy",
 		"start": "wrangler dev",
 		"dev": "wrangler dev",


### PR DESCRIPTION
## Summary

Restore an npm `build` script so Cloudflare Workers Builds configurations that run `npm run build` no longer fail with `Missing script: "build"`.

The script uses `wrangler deploy --dry-run`, which performs Wrangler's compile/bundle validation without deploying. The existing `deploy` script remains unchanged for the actual deployment step.

## Change

```json
"build": "wrangler deploy --dry-run"
```

## Notes

- The `http2@3.3.7` engine message in the reported log is a warning, not the build-stopping error.
- No dependency lockfile update is required because only the scripts section changed.

Closes #37