### PR TITLE
fix(weibo): prefer list timestamps for feed items

### DIFF
--- a/src/lib/weibo/user.js
+++ b/src/lib/weibo/user.js
@@ -46,7 +46,7 @@ let deal = async (ctx) => {
 
 				if (data && data.text) {
 					item.mblog.text = data.text;
-					item.mblog.created_at = weiboUtils.normalizeCreatedAt(data.created_at);
+					item.mblog.created_at = weiboUtils.normalizeCreatedAt(item.mblog.created_at || data.created_at);
 					item.mblog.pics = data.pics;
 					if (item.mblog.retweeted_status && data.retweeted_status) {
 						item.mblog.retweeted_status.created_at = data.retweeted_status.created_at;


### PR DESCRIPTION
Related to #39.

Prefer the timestamp returned by the Weibo list API and use the detail API timestamp only as a fallback. This prevents detail API relative timestamps from being recalculated near the RSS fetch time.

This PR intentionally does not close issue #39 automatically.