### PR TITLE
fix(bilibili): guard dynamic card fields against undefined arrays

### DIFF
--- a/src/lib/bilibili/user/dynamic.js
+++ b/src/lib/bilibili/user/dynamic.js
@@ -38,7 +38,7 @@ let getPubDate = (ptimeLabelText) => {
 let getItemFromDynamicForward = (card) => {
 	// title
 	let title = '';
-	for (let desc of card.extend.desc) {
+	for (let desc of card.extend?.desc || []) {
 		title += desc.text;
 	}
 	// link
@@ -46,7 +46,7 @@ let getItemFromDynamicForward = (card) => {
 	// description
 	let description = title + '<br/>';
 	description += `转发自：@${card.extend.origName}<br/>`;
-	for (let desc of card.extend.origDesc) {
+	for (let desc of card.extend?.origDesc || []) {
 		description += desc.text;
 	}
 	if (card.extend.origImgUrl) {
@@ -56,7 +56,7 @@ let getItemFromDynamicForward = (card) => {
 	let guid = `https://t.bilibili.com/${card.extend.dynIdStr}`;
 	let author = '';
 	let category = card.cardType;
-	for (let _module of card.modules) {
+	for (let _module of card.modules || []) {
 		if (_module.moduleType === 'module_author') {
 			let ptimeLabelText = _module.moduleAuthor?.ptimeLabelText;
 			pubDate = getPubDate(ptimeLabelText);
@@ -77,7 +77,7 @@ let getItemFromDynamicForward = (card) => {
 let getItemFromDynamicAv = (card) => {
 	// title
 	let title = '';
-	for (let desc of card.extend.origDesc) {
+	for (let desc of card.extend?.origDesc || []) {
 		title += desc.text;
 	}
 	// link
@@ -91,7 +91,7 @@ let getItemFromDynamicAv = (card) => {
 	let guid = `https://t.bilibili.com/${card.extend.dynIdStr}`;
 	let author = '';
 	let category = card.cardType;
-	for (let _module of card.modules) {
+	for (let _module of card.modules || []) {
 		if (_module.moduleType === 'module_author') {
 			let ptimeLabelText = _module.moduleAuthor?.ptimeLabelText;
 			pubDate = getPubDate(ptimeLabelText);
@@ -114,14 +114,14 @@ let getItemFromDynamicAv = (card) => {
 let getItemFromDynamicDraw = (card) => {
 	// title
 	let title = '';
-	for (let desc of card.extend.origDesc) {
+	for (let desc of card.extend?.origDesc || []) {
 		title += desc.text;
 	}
 	// link
 	let link = `https://t.bilibili.com/${card.extend.dynIdStr}`;
 	// description
 	let description = title + '<br/>';
-	for (let cover of card.extend?.opusSummary?.covers) {
+	for (let cover of card.extend?.opusSummary?.covers || []) {
 		description += `<img src="${cover.src}"/><br/>`;
 	}
 
@@ -129,7 +129,7 @@ let getItemFromDynamicDraw = (card) => {
 	let guid = `https://t.bilibili.com/${card.extend.dynIdStr}`;
 	let author = '';
 	let category = card.cardType;
-	for (let _module of card.modules) {
+	for (let _module of card.modules || []) {
 		if (_module.moduleType === 'module_author') {
 			let ptimeLabelText = _module.moduleAuthor?.ptimeLabelText;
 			pubDate = getPubDate(ptimeLabelText);
@@ -157,7 +157,7 @@ let getItemFromDynamicDefault = (card) => {
 	let guid = `https://t.bilibili.com/${card.extend.dynIdStr}`;
 	let author = '';
 	let category = card.cardType;
-	for (let _module of card.modules) {
+	for (let _module of card.modules || []) {
 		if (_module.moduleType === 'module_desc') {
 			title = _module.moduleDesc?.text;
 			// description = _module?.moduleDesc?.desc.text;
@@ -168,7 +168,7 @@ let getItemFromDynamicDefault = (card) => {
 		}
 	}
 	if (title === '') {
-		for (let desc of card.extend?.origDesc) {
+		for (let desc of card.extend?.origDesc || []) {
 			title += desc.text;
 		}
 	}
@@ -187,7 +187,7 @@ let getItemFromPaidDynamic = (card) => {
 	let pubDate = new Date().toUTCString();
 	let author = '';
 	let category = card.cardType;
-	for (let _module of card.modules) {
+	for (let _module of card.modules || []) {
 		if (_module.moduleType === 'module_author') {
 			let ptimeLabelText = _module.moduleAuthor?.ptimeLabelText;
 			pubDate = getPubDate(ptimeLabelText);
@@ -206,7 +206,7 @@ let getItemFromPaidDynamic = (card) => {
 };
 
 let getItemFromDynamic = (card) => {
-	if (card.extend.onlyFansProperty.isOnlyFans) {
+	if (card.extend?.onlyFansProperty?.isOnlyFans) {
 		return getItemFromPaidDynamic(card);
 	}
 	switch (card.cardType) {


### PR DESCRIPTION
## 问题描述

`/bilibili/user/dynamic/:uid` 路由会偶发返回 500：

```
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at getItemFromDynamicDraw
    at getItemFromDynamic
    at deal
```

## 根本原因

`GetDynSpace` 通过 `toJsonString()` 序列化 gRPC 响应，而 protobuf-es 的 JSON 序列化会**省略未设置的 message / 空 repeated 字段**。因此 `JSON.parse` 之后，`card.extend.origDesc`、`card.extend.opusSummary.covers`、`card.modules` 可能为 `undefined`，在 `for...of` 循环里直接迭代 `undefined` 就会抛出 `TypeError: undefined is not iterable`，导致整个 feed 返回 500。

例如一条缺少可选内容的「图文动态」序列化后：
```json
{"cardType":"draw","extend":{"dynIdStr":"123"}}
```
此时 `card.extend.origDesc` 和 `card.extend?.opusSummary?.covers` 均为 `undefined`。

## 改动

为所有可能为 `undefined` 的数组迭代加上 `|| []` 兜底，并对 `onlyFansProperty` 使用可选链：

- `card.extend?.desc || []` / `card.extend?.origDesc || []`（forward / av / draw / default 处理器）
- `card.extend?.opusSummary?.covers || []`（draw 处理器，即报错点）
- `card.modules || []`（全部 5 个卡片处理器）
- `card.extend?.onlyFansProperty?.isOnlyFans`（可选链）

共 12 处单行改动，无行为变更（字段存在时行为完全一致，缺失时不再抛错）。

## 验证

- 用会触发崩溃的 draw 卡片形态（仅含 `dynIdStr`）复现测试，所有动态类型均正常返回，不再抛错
- `wrangler deploy --dry-run` 构建通过